### PR TITLE
Correct translation selected

### DIFF
--- a/app/controllers/spree/static_content_controller.rb
+++ b/app/controllers/spree/static_content_controller.rb
@@ -2,15 +2,22 @@ module Spree
   class StaticContentController < StoreController
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
-    include Spree::PagesHelper
     helper 'spree/products'
     layout :determine_layout
 
     def show
-      @page = Spree::Page.joins(:translations).by_store(current_store).visible.find_by!(slug: static_page_slug_with_current_language("/#{params[:path]}"))
+      I18n.with_locale(language_from_locale) do
+        @page = Spree::Page.joins(:translations).by_store(current_store)
+                    .visible
+                    .find_by!(slug: ("/#{params[:path]}"))
+      end
     end
 
     private
+
+    def language_from_locale
+      params[:locale].split("-")&.first || params[:locale]
+    end
 
     def determine_layout
       return @page.layout if @page && @page.layout.present? && !@page.render_layout_as_partial?

--- a/app/controllers/spree/static_content_controller.rb
+++ b/app/controllers/spree/static_content_controller.rb
@@ -6,7 +6,7 @@ module Spree
     layout :determine_layout
 
     def show
-      @page = Spree::Page.joins(:translations).by_store(current_store).visible.find_by!(slug: "/#{params[:path]}")
+      @page = Spree::Page.joins(:translations).by_store(current_store).visible.find_by!(slug: static_page_slug_with_current_language("/#{params[:path]}"))
     end
 
     private

--- a/app/controllers/spree/static_content_controller.rb
+++ b/app/controllers/spree/static_content_controller.rb
@@ -2,6 +2,7 @@ module Spree
   class StaticContentController < StoreController
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
+    include Spree::PagesHelper
     helper 'spree/products'
     layout :determine_layout
 

--- a/app/helpers/spree/pages_helper.rb
+++ b/app/helpers/spree/pages_helper.rb
@@ -4,13 +4,5 @@ module Spree
       page = Spree::Page.find_by_slug(slug)
       raw page.body if page
     end
-
-    def static_page_slug_with_current_language(page_slug)
-      "/#{current_language_from_locale}#{page_slug}"
-    end
-
-    def current_language_from_locale
-      I18n.locale&.to_s&.split("-")&.first || I18n.locale
-    end
   end
 end

--- a/app/helpers/spree/pages_helper.rb
+++ b/app/helpers/spree/pages_helper.rb
@@ -4,5 +4,13 @@ module Spree
       page = Spree::Page.find_by_slug(slug)
       raw page.body if page
     end
+
+    def static_page_slug_with_current_language(page_slug)
+      "/#{current_language_from_locale}#{page_slug}"
+    end
+
+    def current_language_from_locale
+      I18n.locale&.to_s&.split("-")&.first || I18n.locale
+    end
   end
 end

--- a/app/views/spree/admin/pages/_form.html.erb
+++ b/app/views/spree/admin/pages/_form.html.erb
@@ -78,7 +78,7 @@
         <%= f.label :stores, plural_resource_name(Spree::Store) %>
         <% Spree::Store.all.each do |store| %>
           <div class="checkbox">
-            <%= f.label store.name.downcase.to_sym do %>
+            <%= f.label store.name&.downcase&.to_sym do %>
               <%= check_box_tag 'page[store_ids][]', store.id, @page.stores.include?(store) %>
               <%= store.name %>
             <% end %>

--- a/lib/spree_static_content.rb
+++ b/lib/spree_static_content.rb
@@ -17,7 +17,7 @@ module Spree
   class StaticPage
     def self.matches?(request)
       return false if request.path =~ %r{\A\/+(admin|account|cart|checkout|content|login|pg\/|orders|products|s\/|session|signup|shipments|states|t\/|tax_categories|user)+}
-      Spree::Page.joins(:translations).where(spree_page_translations: { slug: "/#{request.parameters[:path]}" }).any?
+      Spree::Page.visible.joins(:translations).where(spree_page_translations: { slug: "/#{request.parameters[:path]}" }).any?
     end
   end
 end

--- a/lib/spree_static_content.rb
+++ b/lib/spree_static_content.rb
@@ -17,7 +17,8 @@ module Spree
   class StaticPage
     def self.matches?(request)
       return false if request.path =~ %r{\A\/+(admin|account|cart|checkout|content|login|pg\/|orders|products|s\/|session|signup|shipments|states|t\/|tax_categories|user)+}
-      !Spree::Page.visible.find_by_slug("/#{request.parameters[:path]}").nil?
+      !Spree::Page.visible.find_by_slug(static_page_slug_with_current_language("/#{params[:path]}")).nil?
+      byebug
     end
   end
 end

--- a/lib/spree_static_content.rb
+++ b/lib/spree_static_content.rb
@@ -15,11 +15,9 @@ end
 
 module Spree
   class StaticPage
-    include Spree::PagesHelper
-
     def self.matches?(request)
       return false if request.path =~ %r{\A\/+(admin|account|cart|checkout|content|login|pg\/|orders|products|s\/|session|signup|shipments|states|t\/|tax_categories|user)+}
-      !Spree::Page.visible.find_by_slug(static_page_slug_with_current_language("/#{request.parameters[:path]}")).nil?
+      Spree::Page.joins(:translations).where(spree_page_translations: { slug: "/#{request.parameters[:path]}" }).any?
     end
   end
 end

--- a/lib/spree_static_content.rb
+++ b/lib/spree_static_content.rb
@@ -15,6 +15,8 @@ end
 
 module Spree
   class StaticPage
+    include PagesHelper
+
     def self.matches?(request)
       return false if request.path =~ %r{\A\/+(admin|account|cart|checkout|content|login|pg\/|orders|products|s\/|session|signup|shipments|states|t\/|tax_categories|user)+}
       !Spree::Page.visible.find_by_slug(static_page_slug_with_current_language("/#{request.parameters[:path]}")).nil?

--- a/lib/spree_static_content.rb
+++ b/lib/spree_static_content.rb
@@ -17,8 +17,7 @@ module Spree
   class StaticPage
     def self.matches?(request)
       return false if request.path =~ %r{\A\/+(admin|account|cart|checkout|content|login|pg\/|orders|products|s\/|session|signup|shipments|states|t\/|tax_categories|user)+}
-      !Spree::Page.visible.find_by_slug(static_page_slug_with_current_language("/#{params[:path]}")).nil?
-      byebug
+      !Spree::Page.visible.find_by_slug(static_page_slug_with_current_language("/#{request.parameters[:path]}")).nil?
     end
   end
 end

--- a/lib/spree_static_content.rb
+++ b/lib/spree_static_content.rb
@@ -15,7 +15,7 @@ end
 
 module Spree
   class StaticPage
-    include PagesHelper
+    include Spree::PagesHelper
 
     def self.matches?(request)
       return false if request.path =~ %r{\A\/+(admin|account|cart|checkout|content|login|pg\/|orders|products|s\/|session|signup|shipments|states|t\/|tax_categories|user)+}


### PR DESCRIPTION
¡Hola!

A partir de ahora, el código de locale que se escogerá para renderizar la página estática será, en caso de que exista en la url idioma_PAIS, sólamente la del idioma. Básicamente es lo que estamos haciendo a lo largo de todo el proyecto de Nícoli, pero nos faltan las páginas estáticas. 

También se ha solucionado un problema de nulidad que había en el nombre de la store cuando determinada traducción no existe. 