### PR TITLE
Fix static page url

### DIFF
--- a/app/controllers/spree/static_content_controller.rb
+++ b/app/controllers/spree/static_content_controller.rb
@@ -16,7 +16,7 @@ module Spree
     private
 
     def language_from_locale
-      params[:locale].split("-")&.first || I18n.locale
+      params[:locale]&.split("-")&.first || I18n.locale
     end
 
     def determine_layout

--- a/app/controllers/spree/static_content_controller.rb
+++ b/app/controllers/spree/static_content_controller.rb
@@ -16,7 +16,7 @@ module Spree
     private
 
     def language_from_locale
-      params[:locale].split("-")&.first || params[:locale]
+      params[:locale].split("-")&.first || I18n.locale
     end
 
     def determine_layout


### PR DESCRIPTION
¡Hola!,
En este PR se arregla el error 500 a los enlaces de páginas estáticas sin una locale definida (idioma por defecto).